### PR TITLE
feat: Add Git, GitHub, WebDAV, and LibArchive backends (v0.4.2)

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -420,3 +420,357 @@ Compression is automatically detected from the file extension.
 - Use ZIP backend if write access is needed
 
 **Note:** Built-in to fsspec, no additional dependencies required.
+
+Git Repositories
+----------------
+
+Read files from local Git repositories at specific commits, branches, or tags.
+
+**Installation:**
+
+.. code-block:: bash
+
+    pip install pygit2
+
+**Configuration:**
+
+.. code-block:: python
+
+    # Access repository at HEAD
+    {
+        'name': 'myrepo',
+        'type': 'git',
+        'path': '/path/to/repo.git'   # required: path to Git repository
+    }
+
+    # Access specific branch/tag/commit
+    {
+        'name': 'production',
+        'type': 'git',
+        'path': '/path/to/repo.git',
+        'ref': 'v1.0.0'               # optional: branch, tag, or commit SHA
+    }
+
+**Usage:**
+
+.. code-block:: python
+
+    # Read file from repository
+    node = storage.node('myrepo:src/main.py')
+    content = node.read()
+
+    # List repository files
+    for item in storage.node('myrepo:src').list():
+        print(item)
+
+    # Compare different versions
+    current = storage.node('production:config.yaml')
+    staging = storage.node('staging:config.yaml')
+    if current.md5 != staging.md5:
+        print("Configuration differs between production and staging")
+
+**Use cases:**
+
+- Read configuration from specific Git commits
+- Access historical versions of files
+- Compare files across branches
+- Browse repository contents without checkout
+- Build tools that need version-specific access
+
+**Features:**
+
+- Access any commit, branch, or tag
+- Read files without full checkout
+- Version history access
+- Fast repository browsing
+- No working directory required
+
+**Limitations:**
+
+- **Read-only**: Cannot commit or modify repository
+- **No write support**: Git repositories are read-only via fsspec
+- Requires pygit2 library
+- Only works with local repositories (use GitHub backend for remote)
+
+**Note:** Requires ``pygit2`` package for Git access.
+
+GitHub Repositories
+-------------------
+
+Read files from GitHub repositories via API, with support for branches, tags, and commits.
+
+**Configuration:**
+
+.. code-block:: python
+
+    # Public repository (no authentication)
+    {
+        'name': 'opensource',
+        'type': 'github',
+        'org': 'genropy',              # required: GitHub organization/user
+        'repo': 'genro-storage'        # required: repository name
+    }
+
+    # Specific branch/tag/commit
+    {
+        'name': 'release',
+        'type': 'github',
+        'org': 'genropy',
+        'repo': 'genro-storage',
+        'sha': 'v1.0.0'                # optional: branch, tag, or commit SHA
+    }
+
+    # Private repository (with authentication)
+    {
+        'name': 'private',
+        'type': 'github',
+        'org': 'mycompany',
+        'repo': 'secret-project',
+        'username': 'myusername',      # required for private repos
+        'token': 'ghp_xxxxxxxxxxxxx'   # required for private repos
+    }
+
+**Usage:**
+
+.. code-block:: python
+
+    # Read file from GitHub
+    node = storage.node('opensource:README.md')
+    content = node.read()
+
+    # Download configuration from release tag
+    config_node = storage.node('release:config/production.yaml')
+    config_node.copy_to(storage.node('local:config.yaml'))
+
+    # List repository contents
+    for item in storage.node('opensource:src').list():
+        print(f"File: {item.name}, Size: {item.size}")
+
+**Authentication:**
+
+For private repositories or to increase API rate limits:
+
+1. Create a Personal Access Token at https://github.com/settings/tokens
+2. Include both ``username`` and ``token`` in configuration
+3. Token needs ``repo`` scope for private repository access
+
+**Use cases:**
+
+- Download configuration from GitHub releases
+- Access documentation files
+- Fetch schemas or templates from repositories
+- CI/CD pipelines reading from GitHub
+- Tools that process files from multiple GitHub repos
+
+**Features:**
+
+- Access public and private repositories
+- Read any commit, branch, or tag
+- No local clone required
+- Works over HTTPS
+- Efficient API-based access
+
+**Limitations:**
+
+- **Read-only**: Cannot push commits
+- **API rate limits**: 60 req/hour (unauthenticated), 5000 req/hour (authenticated)
+- Requires internet connection
+- Not suitable for large binary files (use Git clone for that)
+
+**Note:** Built-in to fsspec, no additional dependencies required. Authentication requires GitHub Personal Access Token.
+
+WebDAV Storage
+--------------
+
+Access remote files via WebDAV protocol (Nextcloud, ownCloud, SharePoint, etc.).
+
+**Installation:**
+
+.. code-block:: bash
+
+    pip install genro-storage[webdav]
+    # or
+    pip install webdav4
+
+**Configuration:**
+
+.. code-block:: python
+
+    # Basic configuration
+    {
+        'name': 'nextcloud',
+        'type': 'webdav',
+        'url': 'https://cloud.example.com/remote.php/dav/files/username'
+    }
+
+    # With username/password authentication
+    {
+        'name': 'sharepoint',
+        'type': 'webdav',
+        'url': 'https://sharepoint.company.com/documents',
+        'username': 'user@company.com',
+        'password': 'secret'
+    }
+
+    # With bearer token authentication
+    {
+        'name': 'owncloud',
+        'type': 'webdav',
+        'url': 'https://owncloud.example.com/remote.php/webdav',
+        'token': 'bearer_token_here'
+    }
+
+**Usage:**
+
+.. code-block:: python
+
+    # Read file from WebDAV
+    node = storage.node('nextcloud:Documents/report.pdf')
+    data = node.read_bytes()
+
+    # Upload file to WebDAV
+    local = storage.node('home:photo.jpg')
+    local.copy_to(storage.node('nextcloud:Photos/vacation.jpg'))
+
+    # Create directory
+    storage.node('sharepoint:Projects/NewProject').mkdir()
+
+    # List remote files
+    for item in storage.node('owncloud:Documents').list():
+        print(f"{item.name}: {item.size} bytes")
+
+    # Delete remote file
+    storage.node('nextcloud:temp/old_file.txt').delete()
+
+**Supported services:**
+
+- **Nextcloud** - Open-source file sync and share
+- **ownCloud** - Enterprise file sync and share
+- **SharePoint** - Microsoft collaboration platform
+- **Box** - Cloud content management
+- **Any WebDAV server** - Standard protocol support
+
+**Use cases:**
+
+- Sync files with Nextcloud/ownCloud
+- Access corporate SharePoint documents
+- Remote file backup and restore
+- Collaborative document management
+- Cross-platform file sharing
+
+**Features:**
+
+- Full read/write support
+- Create and delete files
+- Directory operations
+- Works with any WebDAV-compliant server
+- Standard HTTP/HTTPS protocol
+
+**Limitations:**
+
+- Requires network connection
+- Performance depends on network speed
+- Authentication required for most servers
+- Some servers may have file size limits
+
+**Note:** Requires ``webdav4`` package. Ensure your WebDAV server URL is correct (often includes ``/remote.php/dav/`` for Nextcloud/ownCloud).
+
+LibArchive Storage
+------------------
+
+Read files from various archive formats using libarchive (ZIP, TAR, RAR, 7z, ISO, and more).
+
+**Installation:**
+
+.. code-block:: bash
+
+    pip install genro-storage[libarchive]
+    # or
+    pip install libarchive-c
+
+Note: Also requires system libarchive library:
+
+- **macOS**: ``brew install libarchive``
+- **Ubuntu/Debian**: ``apt-get install libarchive-dev``
+- **CentOS/RHEL**: ``yum install libarchive-devel``
+- **Windows**: Pre-built binaries available
+
+**Configuration:**
+
+.. code-block:: python
+
+    # Read any archive format
+    {
+        'name': 'backup',
+        'type': 'libarchive',
+        'file': '/backups/data.tar.gz'
+    }
+
+    {
+        'name': 'install',
+        'type': 'libarchive',
+        'file': '/downloads/software.zip'
+    }
+
+    {
+        'name': 'iso',
+        'type': 'libarchive',
+        'file': '/images/linux.iso'
+    }
+
+**Usage:**
+
+.. code-block:: python
+
+    # Read from archive
+    node = storage.node('backup:important.txt')
+    content = node.read()
+
+    # List archive contents
+    for item in storage.node('install:').list():
+        print(f"{item.name}: {item.size} bytes")
+
+    # Extract specific files
+    archived = storage.node('backup:database/config.json')
+    archived.copy_to(storage.node('local:restored_config.json'))
+
+    # Browse ISO image contents
+    for file in storage.node('iso:boot').list():
+        print(file.name)
+
+**Supported formats:**
+
+- **ZIP** - ZIP archives
+- **TAR** - TAR archives (with gzip, bzip2, xz, lzma compression)
+- **RAR** - RAR archives
+- **7z** - 7-Zip archives
+- **ISO** - ISO disk images
+- **ARJ** - ARJ archives
+- **CAB** - Microsoft Cabinet files
+- **LHA/LZH** - LHA/LZH archives
+- **And many more** - See libarchive documentation
+
+**Use cases:**
+
+- Read files from RAR archives (unlike ZIP backend)
+- Browse ISO disk images
+- Access files in 7z archives
+- Extract from various legacy archive formats
+- Unified interface for all archive types
+
+**Features:**
+
+- Supports 20+ archive formats
+- Automatic format detection
+- Compression support for most formats
+- Fast archive browsing
+- No temporary extraction required
+
+**Limitations:**
+
+- **Read-only**: Cannot create or modify archives
+- **System dependency**: Requires libarchive library installed
+- **Performance**: May be slower than format-specific backends
+- Not all archive formats support random access
+
+**Note:** Requires both ``libarchive-c`` Python package and system ``libarchive`` library. For write access to ZIP/TAR, use the dedicated ZIP or TAR backends instead.

--- a/genro_storage/backends/fsspec.py
+++ b/genro_storage/backends/fsspec.py
@@ -345,6 +345,116 @@ class FsspecBackend(StorageBackend):
                 temporary=True  # Ephemeral!
             )
 
+        # Git local repositories (read-only)
+        elif protocol == 'git':
+            return BackendCapabilities(
+                read=True,
+                write=False,  # Git is read-only
+                delete=False,
+                mkdir=False,
+                list_dir=True,
+
+                versioning=True,  # Access any commit/tag/branch
+                version_listing=False,  # Can't list all versions
+                version_access=True,  # Can access specific versions via ref
+
+                metadata=False,
+                presigned_urls=False,
+                public_urls=False,
+
+                atomic_operations=False,
+                symbolic_links=False,
+                copy_optimization=False,
+                hash_on_metadata=False,
+
+                append_mode=False,
+                seek_support=True,
+
+                readonly=True,
+                temporary=False
+            )
+
+        # GitHub repositories (read-only, remote)
+        elif protocol == 'github':
+            return BackendCapabilities(
+                read=True,
+                write=False,  # GitHub is read-only via API
+                delete=False,
+                mkdir=False,
+                list_dir=True,
+
+                versioning=True,  # Access any commit/tag/branch
+                version_listing=False,
+                version_access=True,  # Can access specific versions via sha
+
+                metadata=False,
+                presigned_urls=False,
+                public_urls=True,  # GitHub URLs are public
+
+                atomic_operations=False,
+                symbolic_links=False,
+                copy_optimization=False,
+                hash_on_metadata=False,
+
+                append_mode=False,
+                seek_support=True,
+
+                readonly=True,
+                temporary=False
+            )
+
+        # WebDAV (Nextcloud, ownCloud, SharePoint)
+        elif protocol == 'webdav':
+            return BackendCapabilities(
+                read=True,
+                write=True,
+                delete=True,
+                mkdir=True,
+                list_dir=True,
+
+                versioning=False,  # Depends on server
+                metadata=False,
+                presigned_urls=False,
+                public_urls=False,
+
+                atomic_operations=False,
+                symbolic_links=False,
+                copy_optimization=False,
+                hash_on_metadata=False,
+
+                append_mode=True,
+                seek_support=True,
+
+                readonly=False,
+                temporary=False
+            )
+
+        # LibArchive (universal archive support: 7z, rar, iso, etc.)
+        elif protocol == 'libarchive':
+            return BackendCapabilities(
+                read=True,
+                write=False,  # LibArchive is read-only
+                delete=False,
+                mkdir=False,
+                list_dir=True,
+
+                versioning=False,
+                metadata=False,
+                presigned_urls=False,
+                public_urls=False,
+
+                atomic_operations=False,
+                symbolic_links=False,
+                copy_optimization=False,
+                hash_on_metadata=False,
+
+                append_mode=False,
+                seek_support=True,
+
+                readonly=True,
+                temporary=False
+            )
+
         # Default for unknown protocols (conservative)
         else:
             return BackendCapabilities(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "genro-storage"
-version = "0.4.1"
+version = "0.4.2"
 description = "Unified storage abstraction for Genropy framework"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -50,6 +50,12 @@ smb = [
 sftp = [
     "paramiko>=3.0.0",
 ]
+webdav = [
+    "webdav4>=0.9.0",
+]
+libarchive = [
+    "libarchive-c>=5.0",
+]
 async = [
     "asyncer>=0.0.2",
 ]
@@ -60,6 +66,8 @@ all = [
     "aiohttp>=3.8.0",
     "smbprotocol>=1.10.0",
     "paramiko>=3.0.0",
+    "webdav4>=0.9.0",
+    "libarchive-c>=5.0",
     "asyncer>=0.0.2",
 ]
 docs = [


### PR DESCRIPTION
## Summary

Adds support for 4 new storage backends for version 0.4.2:

- **Git**: Read from local Git repositories at specific commits, branches, or tags
- **GitHub**: Access public and private GitHub repositories via API  
- **WebDAV**: Connect to Nextcloud, ownCloud, SharePoint, and other WebDAV servers
- **LibArchive**: Read from various archive formats (RAR, 7z, ISO, and 20+ more formats)

## Changes

### Implementation
- Added Git backend configuration in `manager.py` (requires pygit2)
- Added GitHub backend with username/token authentication support
- Added WebDAV backend with username/password or token auth
- Added LibArchive backend for multi-format archive access
- Added capabilities definitions for all 4 backends in `backends/fsspec.py`

### Tests
- Created comprehensive test suite in `tests/test_additional_backends.py`
- 19 tests covering configuration validation and capabilities
- Proper skip markers for optional dependencies (pygit2, webdav4, libarchive-c)
- All tests passing (7 passed, 12 skipped without optional deps)

### Documentation
- Added detailed sections in `docs/backends.rst` for each backend
- Configuration examples with authentication options
- Usage examples and use cases
- Features and limitations clearly documented
- Installation instructions including system dependencies

### Dependencies
- Updated `pyproject.toml` with optional dependencies
- `webdav4>=0.9.0` for WebDAV support
- `libarchive-c>=5.0` for LibArchive support
- Git and GitHub use fsspec built-in implementations

### Version
- Bumped version to 0.4.2

## Testing

All existing tests pass. New backend tests:
- Git: 4 tests (3 skipped without pygit2, 1 validation passed)
- GitHub: 6 tests (all passed)
- WebDAV: 5 tests (all skipped without webdav4)
- LibArchive: 4 tests (all skipped without libarchive-c)

## Related Issues

Closes #18, #19, #20, #21