### PR TITLE
fix: green the CI — Python floor, pinned test backends, stale tool paths

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,8 +30,8 @@ jobs:
     
     - name: Run Bandit security scan
       run: |
-        bandit -r genro_storage -f json -o bandit-report.json || true
-        bandit -r genro_storage
+        bandit -r src/genro_storage -f json -o bandit-report.json || true
+        bandit -r src/genro_storage
       continue-on-error: true
     
     - name: Check dependencies with Safety
@@ -69,11 +69,11 @@ jobs:
     - name: Calculate complexity
       run: |
         echo "## Cyclomatic Complexity" > complexity-report.md
-        radon cc genro_storage -a -s >> complexity-report.md
-        
+        radon cc src/genro_storage -a -s >> complexity-report.md
+
         echo "" >> complexity-report.md
         echo "## Maintainability Index" >> complexity-report.md
-        radon mi genro_storage >> complexity-report.md
+        radon mi src/genro_storage >> complexity-report.md
         
         cat complexity-report.md
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     
     steps:
     - name: Checkout code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # MinIO - S3-compatible storage
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: genro-storage-minio
     ports:
       - "9000:9000"      # API
@@ -19,6 +19,8 @@ services:
       retries: 5
 
   # SFTP Server
+  # No version tags are published for this image; :latest has not moved in over
+  # two years, so it is effectively pinned already.
   sftp:
     image: atmoz/sftp:latest
     container_name: genro-storage-sftp
@@ -34,6 +36,9 @@ services:
       retries: 5
 
   # Samba/SMB Server
+  # Only architecture tags (amd64/aarch64/armhf) are published besides :latest,
+  # and pinning one of those would break the other architecture. :latest has not
+  # moved in five years.
   samba:
     image: dperson/samba:latest
     container_name: genro-storage-samba
@@ -54,7 +59,7 @@ services:
 
   # WebDAV Server
   webdav:
-    image: bytemark/webdav:latest
+    image: bytemark/webdav:2.4
     container_name: genro-storage-webdav
     ports:
       - "8080:80"
@@ -72,13 +77,16 @@ services:
 
   # Azurite - Azure Storage Emulator
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    image: mcr.microsoft.com/azure-storage/azurite:3.36.0
     container_name: genro-storage-azurite
     ports:
       - "10000:10000"  # Blob service
       - "10001:10001"  # Queue service
       - "10002:10002"  # Table service
-    command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --loose
+    # --skipApiVersionCheck: adlfs tracks the live Azure API version, so a new
+    # adlfs release otherwise fails every request against a pinned emulator with
+    # "The API version <date> is not supported by Azurite".
+    command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --loose --skipApiVersionCheck
     volumes:
       - azurite-data:/data
     healthcheck:
@@ -89,7 +97,7 @@ services:
 
   # fake-gcs-server - Google Cloud Storage Emulator
   fake-gcs:
-    image: fsouza/fake-gcs-server:latest
+    image: fsouza/fake-gcs-server:1.55.1
     container_name: genro-storage-fake-gcs
     ports:
       - "4443:4443"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "genro-storage"
 version = "0.7.0"
 description = "Unified storage abstraction for Genropy framework"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Genropy Team", email = "info@genropy.org"}
@@ -17,10 +17,10 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Filesystems",
 ]


### PR DESCRIPTION
## Description

Both workflows have been red for months, and neither cause is in the library. The
code is fine: with all six docker backends up, **452 tests pass, 7 skip, 0 fail,
at 85% coverage** — the coverage the README already claims. This PR fixes the
three things around it that were broken. No source file is touched.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvement
- [x] Test improvement

## Related Issues

Relates to #46, #47 (both turn out to be declaration bugs, not build failures —
all nine optional extras install cleanly on macOS/py3.13; not fixed here)

## Changes Made

**1. `requires-python` raised to 3.10, matrix becomes 3.10–3.13** — this is why
`Tests` is red. `genro-toolbox` is a hard dependency (`node.py:28` imports
`smartasync` from it) and requires `>=3.10`, while this package declared `>=3.9`
and CI ran a 3.9 leg. That leg cannot resolve `pip install -e ".[all,dev]"` at
all, so the workflow failed regardless of the code. 3.13 is added because the
full suite passes on it.

**2. Docker test backends pinned; Azurite's API version check skipped** — this is
why `Code Quality` is red every Monday. All six backends ran on `:latest`, so a
scheduled run rots whenever an image or a cloud SDK moves, with no commit in
between — exactly the observed pattern since 2025-12-29. minio, azurite,
fake-gcs-server and webdav are now pinned to the versions this suite was verified
against. `atmoz/sftp` publishes no version tags and `dperson/samba` publishes only
architecture tags (pinning one would break the other arch); both images are years
old and effectively frozen, so they keep `:latest` with a comment saying why.

Pinning azurite alone would not be enough: `adlfs` tracks the live Azure API
version, so a new adlfs release fails every request against a pinned emulator
with `The API version 2026-06-06 is not supported by Azurite`. That is what broke
`test_azure_file_operations`. `--skipApiVersionCheck` is Azurite's own documented
escape hatch, named in the error message itself.

**3. `radon` and `bandit` pointed at `src/genro_storage`** — the src/ layout
migration left both aimed at a path that no longer exists. radon exits **0** on a
missing path, so the complexity job stayed green while reporting nothing; bandit's
failure was masked by `continue-on-error`. The complexity report has been empty
since 2026-01-13. With the path fixed, radon analyzes 226 blocks at average
complexity **A (3.22)**.

## Testing

- [x] Unit tests pass locally — `pytest tests/ -m "not integration"` → 383 passed, 9 skipped
- [x] Integration tests pass locally
- [x] All tests pass — `pytest` with `docker compose up -d` → **452 passed, 7 skipped, 0 failed** (was 451 passed / 1 failed before the azurite fix)
- [x] Coverage remains above 80% — **85%**
- [ ] Added new tests for new functionality — none needed, no behaviour changes

Verified on Python 3.13.2, macOS, with all six backends healthy. The 3.10–3.12
legs are unchanged in nature from what CI already ran.

## Documentation

- [ ] Updated docstrings — no code changes
- [ ] Updated README.md — needed, but deliberately not here (see below)

## Two things for you to decide, deliberately left out

**This PR targets `main`, against the Git Flow in `.github/WORKFLOW.md`.** That is
not carelessness: `develop` is currently **25 commits behind `main`** and has zero
commits `main` lacks, so it can be fast-forwarded losslessly. The src/ layout
migration — the very thing that broke the radon path — exists only on `main`, so a
branch off `develop` could not carry this fix. Worth deciding whether `develop`
gets fast-forwarded or retired.

**`ruff`, `black` and `mypy` run but gate nothing.** The `lint` job in
`test.yml` runs all three, each with `continue-on-error: true` and the comment
"Don't fail CI on ... for now", and `test-summary` explicitly excuses them. Their
paths are already correct. Run to completion they report 164 ruff findings, 10
files black would reformat, and 129 mypy errors. Flipping those three flags off is
a decision with real cleanup behind it, not a bug fix, so it is not in this PR.

Related but separate, and also left out on purpose: the README says version 0.4.3
and carries an MIT badge while `pyproject` says 0.7.0 and Apache-2.0; the
`unit` pytest marker is declared but applied to zero tests, so `-m unit` silently
selects nothing (`make test-unit` works because it uses `-m "not integration"`);
and `pyproject` claims 0.7.0 while the latest tag and PyPI are both 0.4.4, i.e.
six months of work is unreleased. Each wants its own change.
