### PR TITLE
ci: bump the GitHub actions to their current majors (supersedes #1-#5)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
     
@@ -41,7 +41,7 @@ jobs:
       continue-on-error: true
     
     - name: Upload security reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: security-reports
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
     
@@ -78,7 +78,7 @@ jobs:
         cat complexity-report.md
     
     - name: Upload complexity report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: complexity-report
         path: complexity-report.md
@@ -88,10 +88,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
 
@@ -156,7 +156,7 @@ jobs:
         echo "BADGE_COLOR=$COLOR" >> $GITHUB_ENV
     
     - name: Upload coverage reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-reports
         path: |
@@ -166,6 +166,6 @@ jobs:
     
     - name: Comment coverage on PR
       if: github.event_name == 'pull_request'
-      uses: py-cov-action/python-coverage-comment-action@v3
+      uses: py-cov-action/python-coverage-comment-action@v4.1
       with:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
     
@@ -39,7 +39,7 @@ jobs:
       run: twine check dist/*
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist
         path: dist/
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist
         path: dist/
@@ -79,7 +79,7 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist
         path: dist/
@@ -100,10 +100,10 @@ jobs:
       contents: write
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist
         path: dist/
@@ -139,7 +139,7 @@ jobs:
         EOF
     
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         files: dist/*
         body_path: release_notes.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -79,7 +79,7 @@ jobs:
     
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.12'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         files: ./coverage.xml
         flags: unittests
@@ -97,7 +97,7 @@ jobs:
     
     - name: Upload coverage HTML
       if: matrix.python-version == '3.12'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-html
         path: htmlcov/
@@ -112,10 +112,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
         cache: 'pip'
@@ -147,10 +147,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
         cache: 'pip'
@@ -166,7 +166,7 @@ jobs:
         make html
     
     - name: Upload docs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: docs-html
         path: docs/_build/html/


### PR DESCRIPTION
## Description

Supersedes the five open dependabot PRs (#1–#5) and closes them. They have been
open since 2025-10-27 and now propose versions that are themselves two to three
majors behind current, so merging them would have left the repo stale on the same
day it was tidied.

| action | in repo | dependabot proposed | current |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | **v7** |
| `actions/setup-python` | v5 | v6 | **v7** |
| `actions/upload-artifact` | v4 | v5 | **v7** |
| `actions/download-artifact` | v4 | v6 | **v8** |
| `softprops/action-gh-release` | v1 | v2 | **v3** |
| `codecov/codecov-action` | v4 | *never offered* | **v7** |
| `py-cov-action/python-coverage-comment-action` | v3 | *never offered* | **v4.1** |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvement

## Related Issues

Closes #1, closes #2, closes #3, closes #4, closes #5

## Changes Made

**Why the last two were never offered.** `dependabot.yml` sets
`open-pull-requests-limit: 5` for the `github-actions` ecosystem, and exactly five
PRs were open — so dependabot has been unable to propose anything new for nine
months. Closing that backlog unblocks the queue as much as bumping does.

**`python-coverage-comment-action@v3` was a broken ref.** That action publishes
only precise tags (`v3.41`, `v4.1`) and never a floating major, so the step could
not resolve whenever it ran. Now pinned to `v4.1`.

**Input compatibility was checked**, not assumed — each action's `action.yml` was
read at the new ref:

- `action-gh-release@v3` still accepts `files`, `body_path`, `draft`, `prerelease`
- `codecov-action@v7` still accepts `files`, `flags`, `name`, `fail_ci_if_error`
- `python-coverage-comment-action@v4.1` still accepts `GITHUB_TOKEN`

`pypa/gh-action-pypi-publish@release/v1` is left alone — a branch ref is what PyPA
documents for that action.

## Testing

CI on this PR exercises everything in `test.yml` (checkout, setup-python,
upload-artifact) plus `codecov-action` on the coverage upload. The full suite ran
green on `main` after #69: 452 passed, 7 skipped, 85% coverage across 3.10–3.13.

**Not exercised by CI, and I want to be explicit about it:** `release.yml` only
triggers on a `v*` tag or `workflow_dispatch`, so `download-artifact@v8` and
`action-gh-release@v3` are first validated at the next release. Their inputs check
out against the new refs, but the path itself is unproven. The
`workflow_dispatch` → `testpypi` route would prove it without touching real PyPI;
that needs the `testpypi` environment (only `release` exists today) and a trusted
publisher configured on TestPyPI. Worth doing before the release the audit calls
for.

## Documentation

- [ ] No documentation changes — CI only, no source or public API touched

## One open question, unrelated to this PR

`Code Quality` did **not** run on #69 or on the merge push, although the workflow
is `active` and its triggers include `push`/`pull_request` on `main`. Its last
non-schedule run was 2026-01-13 and its last run of any kind was 2026-04-13 on
schedule. I have not worked out why yet; noting it so it is not mistaken for
something this PR caused.
