### PR TITLE
chore: repair the github extra, the fake async coverage, and the stale documents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,8 +42,8 @@ Relates to #
 
 - [ ] Updated docstrings
 - [ ] Updated README.md (if needed)
-- [ ] Updated API_DESIGN.md (if API changed)
-- [ ] Updated CHANGELOG.md
+- [ ] Updated `docs/` (if the API changed)
+- [ ] Updated `docs/changelog.rst`
 
 ## Checklist
 

--- a/.github/WORKFLOW.md
+++ b/.github/WORKFLOW.md
@@ -1,172 +1,143 @@
-# Git Flow Workflow - genro-storage
+# Git Workflow - genro-storage
 
 ## Overview
 
-genro-storage uses **Git Flow** with protected branches to ensure code quality and stable releases.
+genro-storage works on a **single long-lived branch**. `main` carries the
+releases; every change arrives through a short-lived topic branch that is deleted
+once merged.
+
+The Git Flow model this project used until 0.4.3 is retired. `develop` was
+removed on 2026-07-30, and the release and hotfix branches went with it: since
+0.7.0 every commit has landed on `main` directly or through a single pull request
+against it.
 
 ## Branch Structure
 
 ```
 main (protected)
   ↑
-  └── PR required
+  └── PR (or a direct push, for administrators)
        ↑
-    develop (protected)
-      ↑
-      └── PR required
-           ↑
-        feature/*
-        bugfix/*
+    feat/*  fix/*  docs/*  refactor/*  test/*  chore/*  hotfix/*
 ```
 
 ### Branch Purposes
 
-| Branch | Purpose | Protected | Merges From | Merges To |
-|--------|---------|-----------|-------------|-----------|
-| `main` | Production releases | ✅ Yes | `develop` (via release), `hotfix/*` | - |
-| `develop` | Integration, next release | ✅ Yes | `feature/*`, `bugfix/*` | `main` (via release) |
-| `feature/*` | New features | ❌ No | - | `develop` |
-| `bugfix/*` | Bug fixes | ❌ No | - | `develop` |
-| `hotfix/*` | Critical production fixes | ❌ No | `main` | `main` + `develop` |
-| `release/*` | Release preparation | ❌ No | `develop` | `main` + `develop` |
+| Branch | Purpose | Protected | Lifetime |
+|--------|---------|-----------|----------|
+| `main` | Releases, tagged `v*` | ✅ Yes | permanent |
+| `feat/*` | New features | ❌ No | deleted after merge |
+| `fix/*` | Bug fixes | ❌ No | deleted after merge |
+| `docs/*` | Documentation only | ❌ No | deleted after merge |
+| `refactor/*`, `test/*`, `chore/*` | Everything else, prefix matching the commit type | ❌ No | deleted after merge |
+| `hotfix/*` | Urgent fix that ships immediately | ❌ No | deleted after merge |
+
+There is no `develop`, no `release/*` and no merge-back step.
 
 ## Protection Rules
 
-Both `main` and `develop` are protected with:
-- ✅ Require pull request before merging
-- ✅ Require 1 approving review
-- ✅ Dismiss stale pull request approvals when new commits are pushed
+`main` is protected, but lightly. What is enforced:
+
 - ❌ No force pushes
 - ❌ No deletions
-- ✅ Linear history not required (allows merge commits)
+
+What is **not** enforced, and is worth knowing before you rely on it:
+
+- No required approving reviews (`required_approving_review_count` is 0)
+- No required status checks — a red CI run does not block a merge
+- Administrators are exempt from the pull request requirement
+  (`enforce_admins` is off), which is how the maintainer lands release commits
+  straight on `main`
+
+Read the live settings rather than trusting this table:
+
+```bash
+gh api repos/genropy/genro-storage/branches/main/protection
+```
 
 ## Common Workflows
 
-### 1. Working on a Feature
+### 1. Working on a Change
 
 ```bash
-# Start from develop
-git checkout develop
-git pull origin develop
+# Start from main
+git checkout main
+git pull origin main
 
-# Create feature branch
-git checkout -b feature/add-webdav-backend
+# Create a topic branch, prefix matching the commit type
+git checkout -b feat/add-webdav-backend
 
 # Make changes, commit
 git add .
 git commit -m "feat: add WebDAV backend support"
 
-# Push and create PR to develop
-git push origin feature/add-webdav-backend
-gh pr create --base develop --head feature/add-webdav-backend
+# Push and open a PR against main
+git push origin feat/add-webdav-backend
+gh pr create --base main --head feat/add-webdav-backend
+
+# After the merge, delete the branch
+git push origin --delete feat/add-webdav-backend
 ```
 
-### 2. Fixing a Bug
+### 2. Cutting a Release
 
 ```bash
-# Start from develop
-git checkout develop
-git pull origin develop
-
-# Create bugfix branch
-git checkout -b bugfix/fix-s3-timeout
-
-# Make changes, commit
-git add .
-git commit -m "fix: increase S3 connection timeout"
-
-# Push and create PR to develop
-git push origin bugfix/fix-s3-timeout
-gh pr create --base develop --head bugfix/fix-s3-timeout
-```
-
-### 3. Creating a Release
-
-```bash
-# Create release branch from develop
-git checkout develop
-git pull origin develop
-git checkout -b release/0.5.0
-
-# Update version and changelog
-vim pyproject.toml  # Update version
-vim CHANGELOG.md    # Add release notes
-
-# Commit release prep
-git add .
-git commit -m "chore: prepare release 0.5.0"
-
-# Push and create PR to main
-git push origin release/0.5.0
-gh pr create --base main --head release/0.5.0 \
-  --title "Release v0.5.0" \
-  --body "Release version 0.5.0 with new features..."
-
-# After PR approval and merge to main:
 git checkout main
 git pull origin main
-git tag -a v0.5.0 -m "Release version 0.5.0"
-git push origin v0.5.0
 
-# Merge back to develop
-gh pr create --base develop --head main \
-  --title "Merge release 0.5.0 back to develop"
+# Bump the single source of truth: __version__ in the package itself.
+# pyproject.toml reads it through [tool.hatch.version] - there is no second place.
+vim src/genro_storage/__init__.py
 
-# Delete release branch
-git branch -d release/0.5.0
-git push origin --delete release/0.5.0
+# Add the entry, newest first
+vim docs/changelog.rst
+
+git add .
+git commit -m "chore: release 0.9.0"
+git push origin main
+
+# The v* tag is what triggers .github/workflows/release.yml and the PyPI publish
+git tag -a v0.9.0 -m "Release version 0.9.0"
+git push origin v0.9.0
 ```
 
-### 4. Hotfix for Production
+Run the full suite with the Docker services up before tagging — see
+[TESTING.md](../TESTING.md). CI does not gate the merge, so this check is yours.
+
+### 3. Urgent Fix
+
+No separate flow: `main` is the release branch, so an urgent fix is an ordinary
+topic branch, `hotfix/` by convention, followed by a patch tag if it has to ship
+straight away.
 
 ```bash
-# Branch from main
 git checkout main
 git pull origin main
 git checkout -b hotfix/critical-security-fix
 
-# Fix issue
 git add .
 git commit -m "fix: patch critical security vulnerability"
-
-# Push and create PR to main
 git push origin hotfix/critical-security-fix
+
 gh pr create --base main --head hotfix/critical-security-fix \
   --title "HOTFIX: Critical security patch"
 
-# After merge to main, also merge to develop
-gh pr create --base develop --head hotfix/critical-security-fix \
-  --title "Merge hotfix to develop"
-
-# Tag hotfix version
+# After the merge
 git checkout main
 git pull origin main
-git tag -a v0.4.2 -m "Hotfix: security patch"
-git push origin v0.4.2
+git tag -a v0.8.1 -m "Hotfix: security patch"
+git push origin v0.8.1
 ```
 
 ## Pull Request Guidelines
 
-### PR to `develop`
+Every PR targets `main`. Requirements:
 
-- Base: `develop`
-- Source: `feature/*` or `bugfix/*`
-- Requirements:
-  - All tests pass
-  - Code coverage maintained
-  - Documentation updated
-  - 1 approving review
-
-### PR to `main`
-
-- Base: `main`
-- Source: `release/*` or `hotfix/*`
-- Requirements:
-  - All tests pass
-  - Version updated in `pyproject.toml`
-  - CHANGELOG.md updated
-  - Release notes prepared
-  - 1 approving review
+- All tests pass, with the Docker services running for the integration ones
+- Coverage maintained
+- Docstrings and `docs/` updated for user-facing changes
+- `docs/changelog.rst` updated
+- Conventional commit messages
 
 ## Commit Message Convention
 
@@ -190,20 +161,16 @@ Types:
 - `chore:` - Maintenance tasks
 - `perf:` - Performance improvements
 
+A `!` after the type marks a breaking change (`refactor!:`, `feat!:`).
+
 Examples:
 ```
 feat: add WebDAV backend support
 fix: resolve S3 timeout issue in large file uploads
 docs: update contributing guidelines
-chore: prepare release 0.5.0
+feat!: per-node encryption with a self-describing envelope
+chore: release 0.9.0
 ```
-
-## Bypassing Protection (Admins Only)
-
-Admins can push directly to protected branches, but **should not**:
-- Use this only for emergency hotfixes
-- Document the reason in commit message
-- Create a follow-up PR for review
 
 ## Tools
 
@@ -211,58 +178,49 @@ Admins can push directly to protected branches, but **should not**:
 
 ```bash
 # Create PR
-gh pr create --base develop --head feature/my-feature
+gh pr create --base main --head feat/my-feature
 
 # List PRs
 gh pr list
 
 # Review PR
-gh pr review 22 --approve
-gh pr review 22 --comment -b "Looks good!"
-gh pr review 22 --request-changes -b "Please fix..."
+gh pr review 74 --approve
+gh pr review 74 --comment -b "Looks good!"
+gh pr review 74 --request-changes -b "Please fix..."
 
 # Merge PR
-gh pr merge 22
-```
+gh pr merge 74
 
-### Check Protection Status
-
-```bash
-# View branch protection
-gh api repos/genropy/genro-storage/branches/main/protection
-
-# View branch protection for develop
-gh api repos/genropy/genro-storage/branches/develop/protection
+# Clean up local branches whose remote is gone
+git fetch --prune
+git branch -vv | grep ': gone]'
 ```
 
 ## Troubleshooting
 
 ### "Protected branch update failed"
 
-This means you tried to push directly to `main` or `develop`. Create a PR instead.
-
-### "Pull request reviews required"
-
-You need at least 1 approving review before merging. Request review from maintainers.
+You tried to force-push to `main`, or to delete it. Neither is allowed; a plain
+push is, for administrators.
 
 ### Merge conflicts
 
 ```bash
-# Update your feature branch with latest develop
-git checkout feature/my-feature
+# Update your topic branch with the latest main
+git checkout feat/my-feature
 git fetch origin
-git merge origin/develop
+git merge origin/main
 # Resolve conflicts
 git add .
-git commit -m "merge: resolve conflicts with develop"
-git push origin feature/my-feature
+git commit -m "merge: resolve conflicts with main"
+git push origin feat/my-feature
 ```
 
 ## Resources
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md) - Full contribution guide
+- [TESTING.md](../TESTING.md) - Running the suite, with and without Docker
 - [Conventional Commits](https://www.conventionalcommits.org/)
-- [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/)
 - [GitHub Protected Branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches)
 
 ---

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,9 +2,9 @@ name: Code Quality
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
   schedule:
     # Run weekly on Monday at 00:00 UTC
     - cron: '0 0 * * 1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
         cat > release_notes.md << 'EOF'
         ## What's Changed
         
-        See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for full details.
+        See the [changelog](https://genro-storage.readthedocs.io/en/latest/changelog.html) for full details.
         
         ## Installation
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
   workflow_dispatch:  # Allow manual trigger
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Read the parent document first for:
 - **Has Implementation Code**: Yes
 - **Version**: 0.8.0
 - **Python Support**: 3.11, 3.12, 3.13
-- **Test Coverage**: 86% (558 tests: 544 passing, 14 skipped)
+- **Test Coverage**: 87% (572 tests: 565 passing, 7 skipped, with the Docker services running; 78% without them)
 - **GitHub**: https://github.com/genropy/genro-storage
 
 ### Project Purpose
@@ -28,19 +28,23 @@ Universal storage abstraction for Python with pluggable backends. Provides unifi
 
 ```
 genro-storage/
-├── genro_storage/          # Main package
+├── src/genro_storage/      # Main package
 │   ├── __init__.py        # Public API exports
-│   ├── manager.py         # StorageManager - main entry point
+│   ├── manager.py         # StorageManager - main entry point, at-rest encryption
 │   ├── node.py            # StorageNode - file/directory abstraction
 │   ├── capabilities.py    # Backend capability system
 │   ├── exceptions.py      # Custom exceptions
 │   ├── storage_grammar.py # StorageConfig / StorageGrammar builder grammar
 │   └── backends/          # Storage backend implementations
 │       ├── base.py        # Abstract backend interface
-│       └── fsspec_backend.py  # Unified fsspec-based backend
+│       ├── fsspec.py      # Unified fsspec-based backend
+│       ├── local.py       # Local filesystem, with callable base_path
+│       ├── base64.py      # Inline base64 data, with writable paths
+│       └── relative.py    # Child mount over a parent mount
 ├── tests/                 # Comprehensive test suite
 ├── docs/                  # ReadTheDocs documentation
-├── API_DESIGN.md         # Detailed API specification
+├── notebooks/             # Executable tutorials, run by tests/test_notebooks.py
+├── doc_to_review/         # Pre-0.7.0 documents, parked and unmaintained
 └── TESTING.md            # Testing instructions with MinIO
 ```
 
@@ -50,11 +54,12 @@ genro-storage/
 - Main entry point for the library
 - Manages mount points (named storage backends)
 - Factory for creating StorageNode instances
-- Configuration loading from YAML/JSON/dict
+- Configuration from a `StorageConfig` grammar, a YAML/JSON path, or a list of dicts
+- Owns the at-rest key material and the encrypt/decrypt boundary
 
 **StorageNode** (`node.py`):
 - Represents a file or directory
-- Unified API: `read()`, `write()`, `copy()`, `exists`, `list()`, `call()`, `serve()`
+- Unified API: `read()`, `write()`, `copy_to()`, `exists()`, `children()`, `call()`, `serve()`
 - Intelligent copy strategies: exists, size, hash
 
 **Supported Backends** (15 total):
@@ -72,11 +77,13 @@ genro-storage/
 6. **Cloud Metadata**: Get/set custom metadata on S3, GCS, Azure
 7. **Callable Paths**: Dynamic path resolution at runtime
 8. **Async Support**: the same StorageManager is awaitable from async code via `@smartasync`
+9. **Pythonic Configuration**: `StorageConfig` grammar, one typed `@element` per protocol, `BagResolver` values in place
+10. **Per-file Encryption**: declared at the write site, stored as a `#GNRE1:<domain>` envelope
 
 ### Architecture Notes
 
 - Built on fsspec for battle-tested storage backends
-- Originated from Genropy framework (19+ years in production, storage since 2018)
+- Originated from Genropy framework (in production since 2006, storage since 2018)
 - Type-hinted codebase with full mypy support
 - Available on PyPI
 
@@ -105,9 +112,9 @@ from genro_storage import StorageManager
 
 storage = StorageManager()
 storage.configure([
-    {'name': 'home', 'type': 'local', 'path': '/home/user'},
-    {'name': 'uploads', 'type': 's3', 'bucket': 'my-app-uploads'},
-    {'name': 'backups', 'type': 'gcs', 'bucket': 'my-backups'},
+    {'name': 'home', 'protocol': 'local', 'base_path': '/home/user'},
+    {'name': 'uploads', 'protocol': 's3', 'bucket': 'my-app-uploads'},
+    {'name': 'backups', 'protocol': 'gcs', 'bucket': 'my-backups'},
 ])
 
 # Use mount points
@@ -115,22 +122,38 @@ node = storage.node('uploads:documents/file.pdf')
 content = node.read()
 ```
 
+`type` and `path` were the field names through 0.4.4; they still work but raise a
+`DeprecationWarning` and go away at 1.0. The typed alternative is the grammar:
+
+```python
+from genro_storage import StorageConfig, StorageManager
+
+class MyConfig(StorageConfig):
+    def main(self, root):
+        m = root.mounts()
+        m.local(name='home', base_path='/home/user')
+        m.s3(name='uploads', bucket='my-app-uploads')
+
+storage = StorageManager()
+storage.configure(MyConfig)
+```
+
 ### Development Guidelines
 
 **Code Quality**:
 ```bash
 # Format
-black genro_storage/ tests/
+black src/genro_storage/ tests/
 
 # Lint
-ruff check genro_storage/ tests/
+ruff check src/genro_storage/ tests/
 
-# Type check
-mypy genro_storage/
+# Type check (advisory, never a gate - see the mypy config in pyproject.toml)
+mypy
 ```
 
 **Documentation**:
-- Keep API_DESIGN.md updated for major API changes
+- Keep `docs/` updated for major API changes; the module docstrings carry the contracts
 - Update docstrings for all public methods
 - ReadTheDocs auto-builds from main branch
 
@@ -143,17 +166,24 @@ mypy genro_storage/
 
 - `fsspec>=2023.1.0` - Core backend support
 - `PyYAML>=6.0` - Configuration file support
-- Optional: `s3fs`, `gcsfs`, `adlfs`, `aiohttp`, `smbprotocol`, `paramiko`, `webdav4`, `libarchive-c`, `cryptography`
+- `genro-toolbox` - `@smartasync`, for the transparent sync/async surface
+- `genro-builders>=0.22.0` - the grammar machinery behind `StorageConfig`
+- `genro-bag>=0.20.1` - `BagResolver`, for configuration values that come from outside
+- Optional: `s3fs`, `gcsfs`, `adlfs`, `aiohttp`, `smbprotocol`, `paramiko`, `webdav4`, `libarchive-c`, `pygit2`, `requests`, `cryptography`
 
 ### Related Documentation
 
-- [API Design](https://github.com/genropy/genro-storage/blob/main/API_DESIGN.md)
 - [Testing Guide](https://github.com/genropy/genro-storage/blob/main/TESTING.md)
 - [ReadTheDocs](https://genro-storage.readthedocs.io)
 - [Jupyter Notebooks](https://github.com/genropy/genro-storage/tree/main/notebooks)
 
+`API_DESIGN.md` is no longer at the root: 0.7.0 parked it in `doc_to_review/`
+along with the other pre-src-layout documents. Nothing there is maintained —
+`docs/` and the docstrings are the current specification.
+
 ---
 
-**All general policies are inherited from the parent document: `/Users/gporcari/Sviluppo/genro_ng/CLAUDE.md`**
+**All general policies are inherited from the parent document: the
+[genro-next-generation CLAUDE.md](https://github.com/genropy/genro-next-generation/blob/main/CLAUDE.md)**
 
-**Last Updated**: 2025-10-30
+**Last Updated**: 2026-08-04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,43 +19,49 @@ By participating in this project, you agree to maintain a respectful and collabo
 
 ## Git Workflow
 
-We use a **Git Flow** workflow with protected branches to ensure code quality and stability.
+We work on a **single long-lived branch**. `main` carries the releases; every
+change arrives through a short-lived topic branch that is deleted once merged.
+The Git Flow model this project used until 0.4.3 is retired: `develop` was
+removed on 2026-07-30, and release and hotfix branches went with it.
 
 ### Branch Structure
 
-- **`main`**: Production-ready code. Protected branch, requires PR and review.
-- **`develop`**: Integration branch for features. Protected branch, requires PR and review.
-- **`feature/*`**: Feature development branches (e.g., `feature/add-webdav-backend`)
-- **`bugfix/*`**: Bug fixes for develop branch
-- **`hotfix/*`**: Urgent fixes for production (branched from main)
-- **`release/*`**: Release preparation branches
+- **`main`**: the only permanent branch. Releases are tagged here.
+- **topic branches**: short-lived, one per change, named after the kind of work —
+  `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`, `hotfix/`. Deleted
+  after the merge.
 
 ### Branch Protection Rules
 
-Both `main` and `develop` branches are protected:
-- **No direct pushes** - All changes must go through Pull Requests
-- **Required reviews** - At least 1 approving review required
-- **No force pushes** - History cannot be rewritten
-- **No deletions** - Branches cannot be deleted
+`main` is protected, but lightly:
+- **No force pushes** - history cannot be rewritten
+- **No deletions** - the branch cannot be removed
+- **Pull requests are the contribution path**, and the place review happens
 
-### Working on Features
+Note what is *not* enforced: there is no required approval count and no required
+status check, and administrators are exempt from the pull request requirement —
+which is how the maintainer lands release commits directly on `main`. If you are
+not an administrator, open a pull request.
 
-1. **Start from develop**:
+### Working on a Change
+
+1. **Start from main**:
    ```bash
-   git checkout develop
-   git pull origin develop
+   git checkout main
+   git pull origin main
    ```
 
-2. **Create a feature branch**:
+2. **Create a topic branch**:
    ```bash
-   git checkout -b feature/your-feature-name
+   git checkout -b feat/your-feature-name
    ```
 
-   Naming conventions:
-   - `feature/add-webdav-backend`
-   - `feature/improve-error-handling`
-   - `bugfix/fix-s3-timeout`
-   - `hotfix/critical-security-fix`
+   Naming conventions — the prefix matches the commit type:
+   - `feat/add-webdav-backend`
+   - `fix/s3-timeout`
+   - `docs/encryption-guide`
+   - `chore/bump-github-actions`
+   - `hotfix/ci-green`
 
 3. **Make your changes**:
    - Write clean, documented code
@@ -82,56 +88,38 @@ Both `main` and `develop` branches are protected:
    ```
 
 6. **Create a Pull Request**:
-   - Go to GitHub and create a PR from your feature branch to `develop`
+   - Open a PR from your topic branch against `main`
    - Fill in the PR template with a clear description
    - Link related issues (e.g., "Closes #15")
    - Wait for review and address feedback
+   - Delete the branch once it is merged
 
 ### Release Process
 
-When ready to release a new version:
+Releases are cut on `main`; there is no release branch.
 
-1. **Create release branch** from `develop`:
-   ```bash
-   git checkout develop
-   git checkout -b release/0.5.0
-   ```
+1. **Bump the version** in `src/genro_storage/__init__.py`. That `__version__` is
+   the single source of truth — `pyproject.toml` reads it through
+   `[tool.hatch.version]`, so there is no second place to edit.
 
-2. **Prepare release**:
-   - Update version in `pyproject.toml`
-   - Update `CHANGELOG.md`
-   - Create release announcement
-   - Run full test suite
+2. **Add the changelog entry** in `docs/changelog.rst`, newest first.
 
-3. **Merge to main**:
-   - Create PR from `release/0.5.0` to `main`
-   - After approval and merge, tag the release:
+3. **Run the full suite** with the Docker services up (see [TESTING.md](TESTING.md)).
+
+4. **Tag on `main`**: pushing a `v*` tag is what triggers the release workflow
+   and the PyPI publish.
    ```bash
    git checkout main
-   git tag -a v0.5.0 -m "Release version 0.5.0"
-   git push origin v0.5.0
+   git pull origin main
+   git tag -a v0.9.0 -m "Release version 0.9.0"
+   git push origin v0.9.0
    ```
 
-4. **Merge back to develop**:
-   - Create PR from `main` to `develop` to sync changes
-   - Delete release branch after merge
+### Urgent Fixes
 
-### Hotfix Process
-
-For critical production issues:
-
-1. **Branch from main**:
-   ```bash
-   git checkout main
-   git checkout -b hotfix/critical-issue
-   ```
-
-2. **Fix and test** thoroughly
-
-3. **Merge to both main and develop**:
-   - Create PR to `main` first
-   - After merge, create PR to `develop`
-   - Tag the hotfix version
+There is no separate hotfix flow: `main` is the release branch, so an urgent fix
+is an ordinary topic branch — `hotfix/` by convention — merged into `main` and
+followed by a patch tag if it needs to ship immediately.
 
 ## Development Setup
 
@@ -177,13 +165,13 @@ For critical production issues:
 
 ```bash
 # Format code
-black genro_storage/ tests/
+black src/genro_storage/ tests/
 
 # Lint
-ruff check genro_storage/ tests/
+ruff check src/genro_storage/ tests/
 
-# Type check
-mypy genro_storage/
+# Type check (advisory, never a gate - see the mypy config in pyproject.toml)
+mypy
 ```
 
 ## Testing Guidelines
@@ -220,7 +208,7 @@ pytest tests/ -v -m "not integration"
 
 1. **Update documentation** for any user-facing changes
 2. **Add tests** for new functionality
-3. **Update CHANGELOG.md** with your changes
+3. **Update `docs/changelog.rst`** with your changes
 4. **Ensure all tests pass** and coverage is maintained
 5. **Request review** from maintainers
 6. **Address feedback** promptly and professionally
@@ -231,7 +219,7 @@ pytest tests/ -v -m "not integration"
 - [ ] Code follows project style guidelines
 - [ ] Tests added/updated and passing
 - [ ] Documentation updated
-- [ ] CHANGELOG.md updated
+- [ ] `docs/changelog.rst` updated
 - [ ] Commits follow conventional commit format
 - [ ] PR description clearly explains the changes
 - [ ] Related issues linked
@@ -259,7 +247,7 @@ make html
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 # genro-storage
 
+[![PyPI](https://img.shields.io/pypi/v/genro-storage.svg)](https://pypi.org/project/genro-storage/)
 [![Python versions](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Documentation Status](https://readthedocs.org/projects/genro-storage/badge/?version=latest)](https://genro-storage.readthedocs.io/en/latest/?badge=latest)
 [![Tests](https://github.com/genropy/genro-storage/workflows/Tests/badge.svg)](https://github.com/genropy/genro-storage/actions)
 [![codecov](https://codecov.io/gh/genropy/genro-storage/branch/main/graph/badge.svg)](https://codecov.io/gh/genropy/genro-storage)
@@ -18,29 +19,33 @@ A modern, elegant Python library that provides a unified interface for accessing
 ## Documentation
 
 - **[Full Documentation](https://genro-storage.readthedocs.io/)** - Complete API reference and guides
-- **[API Design](API_DESIGN.md)** - Detailed design specification
+- **[API Reference](docs/api_reference.rst)** - Every public method, in the docs tree
+- **[Encryption](docs/encryption.rst)** - At-rest encryption, keys and domains
 - **[Testing Guide](TESTING.md)** - How to run tests with MinIO
 - **[Interactive Tutorials](notebooks/)** - Hands-on Jupyter notebooks
+- **[Changelog](docs/changelog.rst)** - Release history
 
 ## Status: Beta - Ready for Production Testing
 
-**Current Version:** 0.4.3
-**Last Updated:** October 2025
+**Current Version:** 0.8.0
+**Last Updated:** August 2026
 
 - Core implementation complete
 - 15 storage backends working (local, S3, GCS, Azure, HTTP, Memory, Base64, SMB, SFTP, ZIP, TAR, Git, GitHub, WebDAV, LibArchive)
-- 521 tests (507 passing, 14 skipped) with 86% coverage on Python 3.11-3.13
+- 572 tests (565 passing, 7 skipped) with 87% coverage on Python 3.11-3.13
 - Full documentation on ReadTheDocs
-- Battle-tested code from Genropy (19+ years in production, storage abstraction since 2018)
+- Battle-tested code from Genropy (20 years in production, storage abstraction since 2018)
 - Available on PyPI
 
 ## Key Features
 
-- **Async/await support** - Transparent sync/async via `@smartasync` decorator
-- **Native permission control** - Configure readonly, readwrite, or delete permissions for any backend
-- **Powered by fsspec** - Leverage 20+ battle-tested storage backends
 - **Mount point system** - Organize storage with logical names like `home:`, `uploads:`, `s3:`
 - **Intuitive API** - Pathlib-inspired interface that feels natural and Pythonic
+- **Async/await support** - Transparent sync/async via `@smartasync`: the same objects work in both contexts
+- **Pythonic configuration** - Declare mounts as typed method calls with the `StorageConfig` grammar, or load YAML/JSON/dicts
+- **Per-file encryption at rest** - Encrypt at the write site; the stored file is a self-describing envelope
+- **Native permission control** - Configure readonly, readwrite, or delete permissions for any backend
+- **Powered by fsspec** - Leverage 20+ battle-tested storage backends
 - **Intelligent copy strategies** - Skip files by existence, size, or hash for efficient incremental backups
 - **Progress tracking** - Built-in callbacks for progress bars and logging during copy operations
 - **Content-based comparison** - Compare files by MD5 hash across different backends
@@ -48,15 +53,12 @@ A modern, elegant Python library that provides a unified interface for accessing
 - **External tool integration** - `call()` method for seamless integration with ffmpeg, imagemagick, pandoc, etc.
 - **WSGI file serving** - `serve()` method for web frameworks (Flask, Django, Pyramid) with ETag caching
 - **MIME type detection** - Automatic content-type detection from file extensions
-- **Flexible configuration** - Load mounts from YAML, JSON, or code
 - **Dynamic paths** - Support for callable paths that resolve at runtime (perfect for user-specific directories)
 - **Cloud metadata** - Get/set custom metadata on S3, GCS, Azure files
 - **URL generation** - Generate presigned URLs for S3, public URLs for sharing
-- **Base64 utilities** - Encode files to data URIs, download from URLs
+- **Base64 data URIs** - Embed data inline with automatic encoding (writable with mutable paths)
 - **S3 versioning** - Access historical file versions (when S3 versioning enabled)
 - **Test-friendly** - In-memory backend for fast, isolated testing
-- **Base64 data URIs** - Embed data inline with automatic encoding (writable with mutable paths)
-- **Production-ready backends** - Built on 6+ years of Genropy production experience
 - **Lightweight core** - Optional backends installed only when needed
 - **Cross-storage operations** - Copy/move files between different storage types seamlessly
 
@@ -66,8 +68,8 @@ While **fsspec** is powerful, genro-storage provides:
 
 - **Mount point abstraction** - Work with logical names instead of full URIs
 - **Simpler API** - Less verbose, more intuitive for common operations
-- **Configuration management** - Load storage configs from files
-- **Enhanced utilities** - Cross-storage copy, unified error handling
+- **Configuration management** - Load storage configs from files or from a typed grammar
+- **Enhanced utilities** - Cross-storage copy, unified error handling, encryption at rest
 
 Think of it as **"requests" is to "urllib"** - a friendlier interface to an excellent foundation.
 
@@ -128,7 +130,7 @@ s3_image.copy_to(b64_image)
 data_uri = f"data:image/jpeg;base64,{b64_image.path}"
 
 # Advanced features
-# 1. Intelligent incremental backups (NEW!)
+# 1. Intelligent incremental backups
 docs = storage.node('home:documents')
 s3_backup = storage.node('uploads:backup/documents')
 
@@ -203,10 +205,73 @@ remote = storage.node('uploads:downloaded.pdf')
 remote.fill_from_url('https://example.com/file.pdf')
 ```
 
+### Pythonic Configuration
+
+Beyond dicts and YAML, mounts can be declared as typed method calls with the
+`StorageConfig` grammar. The element name *is* the protocol, required fields are
+the parameters without a default, and a wrong value is rejected by the signature
+itself rather than at first use:
+
+```python
+from genro_bag.resolvers import EnvResolver
+from genro_storage import StorageConfig, StorageManager
+
+class MyConfig(StorageConfig):
+    def main(self, root):
+        m = root.mounts(storage_key=EnvResolver('STORAGE_KEY'))
+        m.local(name='home', base_path='/srv/data')
+        m.local(name='secure', base_path='/srv/secure', default_encrypted=True)
+        m.s3(name='uploads', bucket='my-bucket',
+             secret_key=EnvResolver('S3_SECRET'))
+        m.relative(name='public', path='home:public', permissions='readonly')
+
+storage = StorageManager()
+storage.configure(MyConfig)
+```
+
+Values that come from outside the recipe — secrets, endpoints, deployment roots —
+are declared in place as a `BagResolver` and resolved once, at configuration
+time. Hosts that embed storage in a larger document mount the vocabulary alone
+through `StorageManager.grammar`.
+
+### Encryption at Rest
+
+Encryption is per file and declared at the write site. Reads need no
+declaration: the stored bytes carry a self-describing envelope — a
+`#GNRE1:<domain>` header followed by the Fernet token — so encrypted and plain
+files coexist in the same directory.
+
+```python
+storage = StorageManager()
+storage.configure(MyConfig)                 # or storage_key='<fernet-key>'
+
+node = storage.node('secure:token.json')
+node.write_text(payload, encrypted=True)    # default domain
+node.write_text(payload, encrypted='acmespa')  # named domain
+print(node.read_text())                     # decrypted, nothing to declare
+```
+
+Key material is one or more comma-separated Fernet keys, each optionally
+prefixed with `<domain>:`. Keys of the same domain group into one `MultiFernet`:
+the first encrypts, all decrypt, which is how a key is rotated. A mount may
+carry `default_encrypted` as the default for writes that declare nothing — an
+explicit `encrypted=` at the write site wins in both directions.
+
+The coverage boundary is deliberate: the paths that hand out or report on the
+stored bytes directly — `open()`, `local_path()` (and the `call()`/`serve()`
+built on it), `copy_to()`/`move_to()`, versioned reads, `size()`/`md5hash()` —
+carry the envelope verbatim, so an encrypted file stays self-describing wherever
+it lands. There is no silent degradation: a domain with no installed key raises
+rather than writing plaintext.
+
+Encryption is opt-in — with no key material no cipher is ever built and
+`cryptography` is never needed. Install it with `pip install genro-storage[encryption]`.
+
 ### Async Usage
 
-All I/O methods use the `@smartasync` decorator for transparent sync/async support.
-The same `StorageManager` and `StorageNode` classes work in both contexts.
+All I/O methods are decorated with `@smartasync`, so the same `StorageManager`
+and `StorageNode` objects work in both contexts: in sync code the methods
+execute directly, in async code they return awaitables.
 
 ```python
 from genro_storage import StorageManager
@@ -271,19 +336,11 @@ async def backup_files(file_list):
 
 ## Learning with Interactive Tutorials
 
-The best way to learn genro-storage is through our **hands-on Jupyter notebooks** in the [`notebooks/`](notebooks/) directory.
-
-### Run Online (No Installation Required)
-
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/genropy/genro-storage/main?filepath=notebooks)
-
-Click the badge above to launch an interactive Jupyter environment in your browser. Ready in ~2 minutes!
-
-### Run Locally
+The best way to learn genro-storage is through our **hands-on Jupyter notebooks** in the [`notebooks/`](notebooks/) directory. They are executed by the test suite on every run, so what they show is what the current release does.
 
 ```bash
-# 1. Install Jupyter
-pip install jupyter notebook
+# 1. Install genro-storage and Jupyter
+pip install "genro-storage[all]" jupyter notebook
 
 # 2. Navigate to notebooks directory
 cd notebooks
@@ -315,19 +372,17 @@ See [notebooks/README.md](notebooks/README.md) for the complete learning guide.
 
 ## Installation
 
-### From GitHub (Recommended)
-
-Install directly from GitHub without cloning:
+### From PyPI
 
 ```bash
 # Base package
-pip install git+https://github.com/genropy/genro-storage.git
+pip install genro-storage
 
 # With S3 support
-pip install "genro-storage[s3] @ git+https://github.com/genropy/genro-storage.git"
+pip install "genro-storage[s3]"
 
-# With all backends
-pip install "genro-storage[all] @ git+https://github.com/genropy/genro-storage.git"
+# With all backends and encryption
+pip install "genro-storage[all]"
 ```
 
 ### From Source (Development)
@@ -358,25 +413,28 @@ Install optional dependencies for specific backends:
 
 ```bash
 # Cloud storage
-pip install genro-storage[s3]          # Amazon S3
-pip install genro-storage[gcs]         # Google Cloud Storage
-pip install genro-storage[azure]       # Azure Blob Storage
+pip install "genro-storage[s3]"          # Amazon S3
+pip install "genro-storage[gcs]"         # Google Cloud Storage
+pip install "genro-storage[azure]"       # Azure Blob Storage
 
 # Network protocols
-pip install genro-storage[http]        # HTTP/HTTPS
-pip install genro-storage[smb]         # SMB/CIFS (Windows/Samba shares)
-pip install genro-storage[sftp]        # SFTP (SSH File Transfer)
-pip install genro-storage[webdav]      # WebDAV (Nextcloud, ownCloud, SharePoint)
+pip install "genro-storage[http]"        # HTTP/HTTPS
+pip install "genro-storage[smb]"         # SMB/CIFS (Windows/Samba shares)
+pip install "genro-storage[sftp]"        # SFTP (SSH File Transfer)
+pip install "genro-storage[webdav]"      # WebDAV (Nextcloud, ownCloud, SharePoint)
 
 # Archive formats
-pip install genro-storage[libarchive]  # RAR, 7z, ISO, and 20+ formats
+pip install "genro-storage[libarchive]"  # RAR, 7z, ISO, and 20+ formats
 
 # Version control
-# Git and GitHub are built-in to fsspec (no extra install needed)
+pip install "genro-storage[git]"         # Local Git repositories (pygit2)
+pip install "genro-storage[github]"      # GitHub repositories (requests)
 
-# Other
-pip install genro-storage[encryption]  # At-rest encryption
-pip install genro-storage[all]         # All backends + encryption
+# Encryption at rest
+pip install "genro-storage[encryption]"  # cryptography
+
+# Everything
+pip install "genro-storage[all]"         # All backends + encryption
 ```
 
 **Built-in backends** (no extra dependencies):
@@ -385,25 +443,26 @@ pip install genro-storage[all]         # All backends + encryption
 - Base64 (inline data URIs)
 - ZIP archives
 - TAR archives (with gzip, bzip2, xz compression)
-- Git repositories (requires system `pygit2`)
-- GitHub repositories
 
 ## Testing
 
 ```bash
 # Unit tests (fast, no external dependencies)
-pytest tests/test_local_storage.py -v
+pytest -m "not integration"
 
-# Integration tests (requires Docker + MinIO)
+# Integration tests (requires Docker: MinIO, fake-gcs, Azurite, SFTP, Samba, WebDAV)
 docker compose -f tests/docker-compose.yml up -d
-pytest tests/test_s3_integration.py -v
+pytest -m integration
 
-# All tests
-pytest tests/ -v
+# All tests, with the services running
+pytest
 
-# With coverage
-pytest tests/ -v --cov=genro_storage
+# Or let Make start the services for you
+make test
 ```
+
+Without the Docker services the integration tests are deselected and coverage
+lands around 78%; with them the full suite reports 87%.
 
 See [TESTING.md](TESTING.md) for detailed testing instructions with MinIO.
 
@@ -411,12 +470,14 @@ See [TESTING.md](TESTING.md) for detailed testing instructions with MinIO.
 
 - [fsspec](https://filesystem-spec.readthedocs.io/) - Pythonic filesystem abstraction
 - [genro-toolbox](https://github.com/genropy/genro-toolbox) - `@smartasync` for transparent sync/async
+- [genro-builders](https://github.com/genropy/genro-builders) - the grammar machinery behind `StorageConfig`
+- [genro-bag](https://github.com/genropy/genro-bag) - `BagResolver`, for configuration values that come from outside
 - Modern Python (3.11+) with full type hints
-- Optional backends: s3fs, gcsfs, adlfs, aiohttp, smbprotocol, paramiko, webdav4, libarchive-c
+- Optional backends: s3fs, gcsfs, adlfs, aiohttp, smbprotocol, paramiko, webdav4, libarchive-c, pygit2, cryptography
 
 ## Origins
 
-genro-storage is extracted and modernized from [Genropy](https://github.com/genropy/genropy), a Python web framework in production since 2006 (19+ years). The storage abstraction layer was introduced in 2018 and has been battle-tested in production for 6+ years. We're making this powerful storage abstraction available as a standalone library for the wider Python community.
+genro-storage is extracted and modernized from [Genropy](https://github.com/genropy/genropy), a Python web framework in production since 2006 (20 years). The storage abstraction layer was introduced in 2018 and has been battle-tested in production ever since. We're making this powerful storage abstraction available as a standalone library for the wider Python community.
 
 ## Development Status
 
@@ -425,63 +486,64 @@ genro-storage is extracted and modernized from [Genropy](https://github.com/genr
 - API Design Complete and Stable
 - Core Implementation Complete
 - FsspecBackend (15 storage backends: local, S3, GCS, Azure, HTTP, Memory, Base64, SMB, SFTP, ZIP, TAR, Git, GitHub, WebDAV, LibArchive)
-- Comprehensive Test Suite (411 tests, 85% coverage)
+- Comprehensive test suite (572 tests, 87% coverage with the Docker services running)
 - CI/CD with Python 3.11, 3.12, 3.13
+- Transparent async/await support via `@smartasync`
+- `StorageConfig` grammar for typed, pythonic configuration
+- Per-file encryption at rest with a self-describing envelope and encryption domains
 - MD5 hashing and content-based equality
 - Base64 backend with writable mutable paths
 - Intelligent copy skip strategies (exists, size, hash, custom)
-- call() method for external tool integration (ffmpeg, imagemagick, etc.)
-- serve() method for WSGI file serving (Flask, Django, Pyramid)
-- mimetype property for automatic content-type detection
-- local_path() context manager for external tools
+- `call()` method for external tool integration (ffmpeg, imagemagick, etc.)
+- `serve()` method for WSGI file serving (Flask, Django, Pyramid)
+- `mimetype` property for automatic content-type detection
+- `local_path()` context manager for external tools
 - Callable path support for dynamic directories
 - Native permission control (readonly, readwrite, delete)
 - Cloud metadata get/set (S3, GCS, Azure)
 - URL generation (presigned URLs, data URIs)
 - S3 versioning support
 - Full Documentation on ReadTheDocs
-- MinIO Integration Testing
-- Transparent async/await support via `@smartasync` decorator
+- Integration testing against MinIO, fake-gcs, Azurite, SFTP, Samba and WebDAV
 - Ready for early adopters and production testing
 - Extended GCS/Azure integration testing in progress
 
 **Recent Releases:**
-- v0.8.0 (July 2026) - Per-node encryption with a self-describing envelope and encoding domains; `default_encrypted` replaces the mount-level `encrypted`
-- v0.7.0 (July 2026) - Unified sync/async via `@smartasync`, removed AsyncStorageManager; at-rest encryption, StorageConfig grammar, Python 3.11 floor
+- v0.8.0 (July 2026) - Per-node encryption with a self-describing envelope and encryption domains; `default_encrypted` replaces the mount-level `encrypted`
+- v0.7.2 (July 2026) - The configuration module is now `storage_grammar`
+- v0.7.1 (July 2026) - `StorageConfig` exported from the package root
+- v0.7.0 (July 2026) - genro-builders 0.22 alignment, `StorageConfig` grammar with in-place resolvers, at-rest encryption, Python 3.11 floor
 - v0.4.2 (October 2025) - Git, GitHub, WebDAV, LibArchive backends
 - v0.4.1 (October 2025) - SMB, SFTP, ZIP, TAR backends
 - v0.4.0 (October 2025) - Relative mounts with permissions, unified read/write API
 - v0.2.0 (October 2025) - Virtual nodes, tutorials, enhanced testing
 
+See [docs/changelog.rst](docs/changelog.rst) for the complete history.
+
 ## Contributing
 
-Contributions are welcome! We follow a **Git Flow** workflow with protected branches for code quality.
+Contributions are welcome!
 
 **Quick Start:**
 1. Read our [Contributing Guide](CONTRIBUTING.md) for detailed workflow and guidelines
-2. Fork the repository and create a feature branch from `develop`
+2. Fork the repository and create a branch
 3. Make your changes with tests and documentation
-4. Submit a Pull Request to the `develop` branch
+4. Open a Pull Request against `main`
 
-**Branch Structure:**
-- `main` - Production releases (protected, requires PR review)
-- `develop` - Integration branch (protected, requires PR review)
-- `feature/*` - Feature development branches
-- `bugfix/*` - Bug fixes
-- `hotfix/*` - Critical production fixes
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for complete workflow documentation.
+`main` is the single long-lived branch: it carries the releases, is protected,
+and requires a reviewed PR. Work happens on short-lived topic branches that are
+deleted once merged.
 
 **Areas for contribution:**
 - Add integration tests for GCS and Azure backends
-- Improve test coverage (target: 90%+)
+- Widen the async coverage in `tests/test_async.py` to the cloud backends
 - Add integration tests for new backends (SMB, SFTP, WebDAV, etc.)
 - Performance optimizations
 - Additional backend implementations
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details
+Apache License 2.0 - See [LICENSE](LICENSE) for details
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,7 +39,9 @@ make help
 tests/
 ├── conftest.py                     # Shared fixtures and helpers
 ├── test_local_storage.py           # Unit tests (no Docker)
-├── test_memory_storage.py          # Unit tests (no Docker)
+├── test_config_grammar.py          # Unit tests, StorageConfig grammar (no Docker)
+├── test_encryption.py              # Unit tests, at-rest encryption (no Docker)
+├── test_notebooks.py               # Executes the notebooks/ tutorials (no Docker)
 ├── test_s3_integration.py          # Integration tests (requires MinIO)
 ├── test_additional_backends.py     # Integration tests (GCS, WebDAV, Azure)
 ├── test_new_backends.py            # Integration tests (SMB, SFTP)

--- a/docs/appendix/architecture.rst
+++ b/docs/appendix/architecture.rst
@@ -696,7 +696,10 @@ Design Principles Applied
 Performance Benchmarks
 ----------------------
 
-Based on test suite (411 tests, 85% coverage):
+Indicative orders of magnitude observed while developing the library, not
+measurements produced by the test suite — there is no benchmark suite in the
+repository, so treat every figure below as a rough expectation rather than a
+guarantee:
 
 **Operation Speed** (local filesystem):
 
@@ -752,8 +755,8 @@ genro-storage provides a clean, extensible architecture for universal storage ab
 - **Layered Design**: Clear separation of concerns
 - **Extensible**: Easy to add new backends and features
 - **Performant**: Optimized for common operations
-- **Well-Tested**: 85% coverage with 411 tests
-- **Production-Ready**: Based on 6+ years of Genropy production use
+- **Well-Tested**: 87% coverage with 572 tests
+- **Production-Ready**: Based on the Genropy storage layer, in production since 2018
 
 The architecture balances:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,49 @@ All notable changes to genro-storage will be documented here.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+----------
+
+Added
+~~~~~
+
+- New optional extra ``genro-storage[github]``. fsspec's github filesystem
+  imports ``requests``, which the base install never pulled in, so a GitHub
+  mount failed with ``ImportError`` unless the ``gcs`` or ``azure`` extra
+  happened to be installed. ``requests`` joins ``all`` as well.
+- ``tests/test_async.py``: the async branch of ``@smartasync``, as real
+  coroutines — reads, writes, stat, directories, cross-mount copy, delete,
+  concurrent writes and an encrypted round trip.
+
+Removed
+~~~~~~~
+
+- The ``--async-mode`` pytest flag. It wrapped each sync test body in
+  ``asyncio.to_thread``, which runs it on a worker thread with no event loop:
+  ``is_async_context()`` was False there, so the sync branch executed and the
+  flag verified nothing about async.
+
+Fixed (documentation)
+~~~~~~~~~~~~~~~~~~~~~
+
+- The README announced version 0.4.3, October 2025 and the **MIT** license; the
+  license has been Apache-2.0 since 0.4.4. ``CONTRIBUTING.md`` and
+  ``docs/contributing.rst`` carried the same MIT claim.
+- Git Flow is documented as retired: ``develop`` was removed on 2026-07-30, and
+  ``CONTRIBUTING.md``, ``.github/WORKFLOW.md`` and the CI triggers still
+  described it. The branch protection rules now match what the GitHub API
+  actually reports.
+- The release process pointed at ``pyproject.toml`` for the version bump, which
+  is ``dynamic``: the single source is ``__version__`` in
+  ``src/genro_storage/__init__.py``.
+- Dead links: ``API_DESIGN.md`` (parked in ``doc_to_review/`` at 0.7.0) and
+  ``CHANGELOG.md`` at the repository root, the latter linked from every
+  generated GitHub release note.
+- The Binder badge was removed: no dependency file has ever existed for it, so
+  the environment it launched could not import the package.
+- 0.4.3 and 0.4.4 are documented below, and 0.4.1/0.4.2 are marked as the
+  unreleased milestones they were.
+
 0.8.0 - July 2026
 -----------------
 
@@ -124,6 +167,62 @@ Dependencies
   sub-builder by reference).
 - ``genro-bag>=0.20.1`` added as a direct dependency (0.20.0 imports
   ``typing_extensions`` without declaring it, so a clean install fails).
+
+0.4.4 - November 2025
+---------------------
+
+Changed
+~~~~~~~
+
+- **Breaking (licensing)**: the project moved from the MIT License to the
+  **Apache License 2.0**, with an ``SPDX-License-Identifier`` header on every
+  module. The README and the contributing guides kept announcing MIT until
+  0.8.0; the ``LICENSE`` file has been Apache-2.0 since this release.
+- Capabilities are auto-derived per protocol: the ``@capability`` decorator
+  populates ``PROTOCOL_CAPABILITIES``, and ``get_capabilities(protocol)`` is the
+  single entry point for single- and multi-protocol backends alike. Declaring a
+  capability twice is no longer possible.
+
+Added
+~~~~~
+
+- Test infrastructure that starts what it needs: ``scripts/start_test_services.sh``
+  and ``stop_test_services.sh``, a ``Makefile`` with ``test`` / ``test-unit`` /
+  ``test-integration`` / ``test-all``, and service-backed tests that skip on a
+  port check instead of failing when a service is down.
+- ``api_introspection``, a JSON description of the public surface derived from
+  the decorated methods. Removed again in 0.7.0 together with the
+  ``genro_core`` decorators.
+
+0.4.3 - October 2025
+--------------------
+
+The first release of the 0.4 line to reach PyPI. It carries everything listed
+under 0.4.1 and 0.4.2 below — those two were development milestones on
+``develop``, never tagged and never published — plus:
+
+Added
+~~~~~
+
+- Native permission control for every backend type (readonly, readwrite,
+  delete), validated against the backend's capabilities at configuration time.
+- Integration tests against Azurite (Azure), fake-gcs-server (GCS) and HTTP,
+  plus wider S3 versioning coverage.
+- Complete coverage for ``RelativeMountBackend`` (75% → 96%) and
+  ``BackendCapabilities`` (88% → 100%). Overall: 79% → 85%.
+
+Changed
+~~~~~~~
+
+- CI starts the full set of Docker services for the integration job, on
+  ``docker compose`` v2 syntax; health checks for the optional services no
+  longer block the run.
+
+.. note::
+
+   0.4.1 and 0.4.2 were never released: there is no tag, no GitHub release and
+   no PyPI artifact for either. Their entries are kept below because they
+   describe real work — it simply reached users with 0.4.3.
 
 0.4.2 - October 2025
 --------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -53,12 +53,17 @@ Pull Request Process
 --------------------
 
 1. Fork the repository
-2. Create a feature branch
+2. Create a topic branch off ``main``, prefixed with the commit type
+   (``feat/``, ``fix/``, ``docs/``, ``chore/``)
 3. Make your changes
 4. Add tests for new features
 5. Ensure all tests pass
 6. Run code formatters
-7. Submit a pull request
+7. Submit a pull request against ``main``
+
+``main`` is the only long-lived branch. See
+`WORKFLOW.md <https://github.com/genropy/genro-storage/blob/main/.github/WORKFLOW.md>`_
+for the full branching and release process.
 
 Guidelines
 ----------
@@ -83,4 +88,4 @@ Include:
 License
 -------
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,16 +1,13 @@
 # genro-storage Interactive Tutorials
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/genropy/genro-storage/main?filepath=notebooks)
-
-Welcome! These Jupyter notebooks provide hands-on, interactive tutorials for learning genro-storage.
+Welcome! These Jupyter notebooks provide hands-on, interactive tutorials for
+learning genro-storage. They are executed by the test suite
+(`tests/test_notebooks.py`) on every run, so what they show is what the current
+release does.
 
 ## 🚀 Quick Start
 
-### Option 1: Run Online (Easiest)
-
-**Click the Binder badge above** ☝️ to launch an interactive Jupyter environment in your browser. No installation required!
-
-### Option 2: Run Locally
+### Option 1: Run Locally
 
 ```bash
 # Install genro-storage and Jupyter
@@ -22,14 +19,14 @@ jupyter notebook
 # Open 01_quickstart.ipynb and start learning!
 ```
 
-### Option 3: Run From a Clone, Without Installing
+### Option 2: Run From a Clone, Without Installing
 
-The package lives in `src/`, so pointing `PYTHONPATH` at it is enough. Its three
+The package lives in `src/`, so pointing `PYTHONPATH` at it is enough. Its
 runtime dependencies still have to be there — only genro-storage itself is not
 installed:
 
 ```bash
-pip install jupyter notebook fsspec PyYAML genro-toolbox
+pip install jupyter notebook fsspec PyYAML genro-toolbox genro-builders genro-bag
 PYTHONPATH=../src jupyter notebook
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ libarchive = [
 git = [
     "pygit2>=1.13.0",
 ]
+# fsspec's github filesystem is import-time dependent on requests, which the
+# base install does not pull in: without this extra a github mount raises
+# ImportError on first use.
+github = [
+    "requests>=2.31.0",
+]
 encryption = [
     "cryptography>=42.0.0",
 ]
@@ -73,6 +79,7 @@ all = [
     "webdav4>=0.9.0",
     "libarchive-c>=5.0",
     "pygit2>=1.13.0",
+    "requests>=2.31.0",
     "cryptography>=42.0.0",
 ]
 docs = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,17 +4,15 @@ This module provides fixtures to set up and tear down MinIO for integration test
 MinIO provides a local S3-compatible object storage for testing.
 
 Async Testing Support:
-    By default, tests run in sync mode. Use --async-mode to run in async context:
-
-    # Run sync tests (default)
-    pytest tests/
-
-    # Run async tests (verifies smartasync works in async context)
-    pytest tests/ --async-mode
+    The async branch of ``@smartasync`` lives in ``test_async.py``, as real
+    coroutines. There is deliberately no flag to re-run the sync suite "in async
+    mode": the only way to do that would be to push each sync test body onto a
+    worker thread, where no event loop runs, so ``is_async_context()`` is False
+    and the sync branch executes anyway. A ``--async-mode`` flag doing exactly
+    that used to live here; it was removed because it verified nothing.
 """
 
 import pytest
-import asyncio
 import boto3
 from botocore.exceptions import ClientError
 import time
@@ -22,61 +20,6 @@ import os
 import tempfile
 import shutil
 import socket
-
-
-# =============================================================================
-# Async Mode Support
-# =============================================================================
-
-def pytest_addoption(parser):
-    """Add --async-mode option to pytest."""
-    parser.addoption(
-        "--async-mode",
-        action="store_true",
-        default=False,
-        help="Run tests in async context (wraps sync calls in asyncio.to_thread)",
-    )
-
-
-@pytest.fixture(scope="session")
-def async_mode(request):
-    """Return True if running in async mode."""
-    return request.config.getoption("--async-mode")
-
-
-@pytest.fixture(autouse=True)
-def run_in_async_context(request, async_mode):
-    """Wrap test execution in async context if --async-mode is set."""
-    if not async_mode:
-        # Sync mode: run test normally
-        yield
-        return
-
-    # Async mode: wrap the test in an event loop
-    # This makes smartasync detect async context and use asyncio.to_thread
-    item = request.node
-
-    # Skip if test is already async
-    if asyncio.iscoroutinefunction(item.obj):
-        yield
-        return
-
-    # Store original test function
-    original_func = item.obj
-
-    async def async_wrapper(*args, **kwargs):
-        """Run sync test inside async context via to_thread."""
-        return await asyncio.to_thread(original_func, *args, **kwargs)
-
-    def sync_runner(*args, **kwargs):
-        """Entry point that runs the async wrapper."""
-        return asyncio.run(async_wrapper(*args, **kwargs))
-
-    # Replace test function
-    item.obj = sync_runner
-    yield
-    # Restore (not strictly necessary but clean)
-    item.obj = original_func
 
 
 def is_service_available(host, port, timeout=1):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2025 Softwell Srl, Milano, Italy
+# SPDX-License-Identifier: Apache-2.0
+
+"""The async half of the ``@smartasync`` surface.
+
+Every I/O method of :class:`~genro_storage.node.StorageNode` is decorated with
+``@smartasync``: in a sync caller it runs directly, in a coroutine it returns an
+awaitable. The rest of the suite only ever exercises the first branch, so
+without this module the async contract the README advertises is entirely
+unverified.
+
+The tests here run as real coroutines, which is the only way to get
+``is_async_context()`` to be true. Wrapping a sync test body in
+``asyncio.to_thread`` does NOT work: the body lands on a worker thread with no
+running loop, ``@smartasync`` takes the sync branch, and the test proves
+nothing about async at all.
+
+Two properties are checked throughout:
+
+- the awaited result equals what the sync call returns;
+- the un-awaited call is an awaitable, i.e. the decorator really did switch
+  branch rather than doing the work eagerly.
+"""
+
+import asyncio
+import inspect
+
+import pytest
+from genro_toolbox import is_async_context
+
+from genro_storage import StorageManager
+
+try:
+    from cryptography.fernet import Fernet
+
+    HAS_CRYPTOGRAPHY = True
+except ImportError:
+    HAS_CRYPTOGRAPHY = False
+
+
+@pytest.fixture
+def storage(tmp_path):
+    """A manager with one local mount and one memory mount."""
+    manager = StorageManager()
+    manager.configure(
+        [
+            {"name": "home", "protocol": "local", "base_path": str(tmp_path)},
+            {"name": "mem", "protocol": "memory"},
+        ]
+    )
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_async_context_is_detected():
+    """The premise of every test below: a coroutine IS an async context."""
+    assert is_async_context() is True
+    # And a worker thread is not - this is why --async-mode used to be a no-op.
+    assert await asyncio.to_thread(is_async_context) is False
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_text(storage):
+    node = storage.node("home:greeting.txt")
+    await node.write_text("hello async")
+    assert await node.read_text() == "hello async"
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_bytes(storage):
+    node = storage.node("home:payload.bin")
+    await node.write_bytes(b"\x00\x01\x02")
+    assert await node.read_bytes() == b"\x00\x01\x02"
+
+
+@pytest.mark.asyncio
+async def test_io_methods_return_awaitables(storage):
+    """The decorator switches branch instead of doing the work eagerly."""
+    node = storage.node("home:probe.txt")
+
+    pending = node.write_text("probe")
+    assert inspect.isawaitable(pending)
+    await pending
+
+    pending = node.exists()
+    assert inspect.isawaitable(pending)
+    assert await pending is True
+
+
+@pytest.mark.asyncio
+async def test_stat_surface(storage):
+    node = storage.node("home:sized.txt")
+    await node.write_text("12345")
+
+    assert await node.exists() is True
+    assert await node.is_file() is True
+    assert await node.is_dir() is False
+    assert await node.size() == 5
+    assert await node.mtime() is not None
+    assert await node.md5hash() == await node.md5hash()
+
+
+@pytest.mark.asyncio
+async def test_non_io_properties_stay_sync(storage):
+    """Properties are not decorated: they must not become awaitables."""
+    node = storage.node("home:report.pdf")
+
+    assert node.mimetype == "application/pdf"
+    assert node.basename == "report.pdf"
+    assert not inspect.isawaitable(node.path)
+
+
+@pytest.mark.asyncio
+async def test_directory_surface(storage):
+    parent = storage.node("home:tree")
+    await parent.mkdir()
+
+    for name in ("a.txt", "b.txt"):
+        await storage.node(f"home:tree/{name}").write_text(name)
+
+    children = await parent.children()
+    assert sorted(child.basename for child in children) == ["a.txt", "b.txt"]
+    assert await parent.is_dir() is True
+
+
+@pytest.mark.asyncio
+async def test_copy_between_mounts(storage):
+    source = storage.node("home:source.txt")
+    await source.write_text("carried across")
+
+    dest = storage.node("mem:copied.txt")
+    await source.copy_to(dest)
+
+    assert await dest.read_text() == "carried across"
+    assert await source.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_delete(storage):
+    node = storage.node("home:transient.txt")
+    await node.write_text("here")
+    assert await node.exists() is True
+
+    await node.delete()
+    assert await node.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writes_are_independent(storage):
+    """The point of the async surface: many files in flight at once."""
+
+    async def write_one(index: int) -> str:
+        node = storage.node(f"home:batch/file_{index}.txt")
+        await node.write_text(f"content {index}")
+        return await node.read_text()
+
+    results = await asyncio.gather(*(write_one(i) for i in range(10)))
+    assert results == [f"content {i}" for i in range(10)]
+
+
+@pytest.mark.skipif(not HAS_CRYPTOGRAPHY, reason="requires the [encryption] extra")
+@pytest.mark.asyncio
+async def test_encrypted_write_and_read(tmp_path):
+    """Encryption rides on write_bytes/read_bytes, so it must work awaited too."""
+    manager = StorageManager()
+    manager.configure(
+        [{"name": "secure", "protocol": "local", "base_path": str(tmp_path)}],
+        storage_key=Fernet.generate_key().decode(),
+    )
+
+    node = manager.node("secure:token.json")
+    await node.write_text('{"tok": 1}', encrypted=True)
+
+    assert await node.read_text() == '{"tok": 1}'
+    # The stored bytes carry the envelope, not the plaintext.
+    assert (tmp_path / "token.json").read_bytes().startswith(b"#GNRE1:")
+
+
+def test_sync_still_works_alongside(storage):
+    """A plain sync test in the same module: no event loop leaks into it."""
+    node = storage.node("home:sync.txt")
+    node.write_text("plain")
+    assert node.read_text() == "plain"
+    assert node.exists() is True


### PR DESCRIPTION
Three unrelated defects found while auditing the repository against its own
documents. No file under `src/` changes behaviour beyond the packaging fix.

## 1. A GitHub mount could not be used

fsspec's github filesystem imports `requests`, which the base install never
pulled in: mounting a GitHub repository raised `ImportError` unless the `gcs`
or `azure` extra happened to be installed and dragged it in. New optional
extra `genro-storage[github]`; `requests` joins `all`.

## 2. The async half of the API was untested, and looked tested

Every I/O method of `StorageNode` is decorated with `@smartasync`, and the
suite only ever exercised the sync branch.

A `--async-mode` pytest flag existed and promised exactly this coverage. It
wrapped each sync test body in `asyncio.to_thread`, which runs it on a worker
thread where no event loop is running, so `is_async_context()` was `False`,
`@smartasync` took the sync branch, and the suite went green in "async mode"
without executing a single line of async code. It is not fixable in place: a
sync body genuinely placed in an event loop breaks, because `node.read()`
returns an awaitable there and the sync assertions fail.

Removed, with the reason recorded in the conftest docstring. `tests/test_async.py`
replaces it with 12 tests written as real coroutines — text and bytes round
trips, `stat`, directories, cross-mount copy, delete, ten concurrent writes via
`asyncio.gather`, an encrypted round trip — plus two guards: one on the premise
(`is_async_context()` is `True` in a coroutine and `False` inside `to_thread`),
one asserting the un-awaited calls really are awaitable, i.e. the decorator
switched branch instead of doing the work eagerly.

## 3. The documents described a different project

- **License**: README, `CONTRIBUTING.md` and `docs/contributing.rst` announced
  **MIT**. The project moved to Apache-2.0 in 0.4.4 (November 2025) with an SPDX
  header on every module; only `LICENSE` was updated at the time.
- **Git Flow**: `develop` was removed on 2026-07-30, but the CI triggers,
  `.github/WORKFLOW.md` and the contributing guides still described it. `main`
  is now documented as the only long-lived branch, the protection rules match
  what the GitHub API reports, and the release process points at `__version__`
  in `src/genro_storage/__init__.py` rather than the `dynamic` pyproject version.
- **Dead links**: `API_DESIGN.md` (parked in `doc_to_review/` at 0.7.0) and
  `CHANGELOG.md` at the repository root — the latter linked from every generated
  release note. The Binder badge is gone too: no dependency file has ever
  existed for it, so the environment it launched could not import the package.
- **Stale figures**: version 0.4.3 / October 2025 and test counts from three
  releases ago. The architecture appendix's performance table is now labelled
  for what it is — indicative orders of magnitude, not measurements, since the
  repository has no benchmark suite.
- **Changelog**: an `Unreleased` section for the above, plus the missing 0.4.3
  and 0.4.4 entries. 0.4.1 and 0.4.2 were documented but never existed (no tag,
  no GitHub release, no PyPI artifact); the two that actually shipped were absent.

## Verification

`pytest tests/` on this branch, without the Docker backends running:
**511 passed, 61 skipped, 0 failed**. With the services up the same tree gave
565 passed / 7 skipped / 87% coverage when the work was written. Sphinx builds
clean under `-W`; `ruff` is clean on the new test module (the eight findings on
`conftest.py` are pre-existing and identical to the `main` baseline).
